### PR TITLE
Fix logic error where timeouts return '🔴' instead of '⚪'

### DIFF
--- a/checks/check_website_load_time.py
+++ b/checks/check_website_load_time.py
@@ -92,7 +92,7 @@ def check_website_load_time(website: str, num_attempts: int = 3) -> str:
 
     except Timeout:
         logger.warning(f"Timeout occurred while checking load time for {website}")
-        return "🔴"  # Timeout is effectively a slow load time
+        return "⚪"  # Timeout is effectively an error/unavailable state
     except HTTPError as e:
         logger.warning(f"HTTP error for {website}: {e}")
         return "⚪"


### PR DESCRIPTION
### FabGPT — code quality

**File:** `checks/check_website_load_time.py`

**Rationale:** The current code incorrectly categorizes timeouts as '🔴' (slow), but the docstring explicitly states that errors or timeouts should return '⚪'. This is a logical contradiction that causes the function to return a status indicating a slow load when the service is actually unresponsive. The fix aligns the return value with the documented contract.

_Proposed by FabGPT OS and approved by a human before opening._

---
🤖 **FabGPT OS** · source `quality` · model `qwen/qwen3.5-9b` · task `c3f53ff63b91348a` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"c3f53ff63b91348a","source":"quality","model":"qwen/qwen3.5-9b","severity":"INFO","iterations":1,"inference_s":67.13,"prompt_sha":"50ea4d3c4978a2d9","triage":"INFO"} -->