### PR TITLE
Remove intrusive logging configuration from module

### DIFF
--- a/checks/check_website_load_time.py
+++ b/checks/check_website_load_time.py
@@ -4,9 +4,9 @@ import requests
 import logging
 from requests.exceptions import RequestException, Timeout, HTTPError
 
-# Configure logging
-logging.basicConfig(level=logging.INFO)
+# Configure module logger without altering global logging configuration
 logger = logging.getLogger(__name__)
+
 
 def check_website_load_time(website: str, num_attempts: int = 3) -> str:
     """


### PR DESCRIPTION
### FabGPT — code quality

**File:** `checks/check_website_load_time.py`

**Rationale:** The module calls logging.basicConfig at import time, which can unintentionally alter the logging configuration of applications that import it. Removing this call prevents side effects while preserving existing log messages for callers that configure logging themselves.

_Proposed by FabGPT OS and approved by a human before opening._

---
🤖 **FabGPT OS** · source `quality` · model `gpt-oss-120b` · task `c3f53ff63b91348a` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"c3f53ff63b91348a","source":"quality","model":"gpt-oss-120b","severity":"INFO","iterations":1,"inference_s":17.46,"prompt_sha":"d73ce4126924bdd3","triage":"INFO"} -->