### PR TITLE
Add validation for HTTP(S) scheme and domain structure

### DIFF
--- a/checks/check_website_load_time.py
+++ b/checks/check_website_load_time.py
@@ -2,6 +2,7 @@ import time
 import statistics
 import requests
 import logging
+from urllib.parse import urlparse
 from requests.exceptions import RequestException, Timeout, HTTPError
 
 # Configure module logger without altering global logging configuration
@@ -29,8 +30,26 @@ def check_website_load_time(website: str, num_attempts: int = 3) -> str:
         return "⚪"
     
     website = website.strip()
+    if not website:
+        logger.error("Empty website string after stripping")
+        return "⚪"
+
+    # Normalize URL with scheme
     if not website.startswith(('http://', 'https://')):
         website = f"https://{website}"
+
+    # Validate URL structure
+    try:
+        parsed = urlparse(website)
+        if not parsed.scheme or not parsed.netloc:
+            logger.error(f"Invalid URL structure: {website}")
+            return "⚪"
+        if parsed.scheme not in ('http', 'https'):
+            logger.error(f"Unsupported scheme in URL: {website}")
+            return "⚪"
+    except Exception as e:
+        logger.error(f"Failed to parse URL {website}: {e}")
+        return "⚪"
 
     headers = {
         'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36',


### PR DESCRIPTION
### FabGPT — code quality

**File:** `checks/check_website_load_time.py`

**Rationale:** The current URL normalization only prepends 'https://' if missing, but does not validate that the resulting URL has a valid domain structure (e.g., 'http://.com' or 'ftp://example.com' would pass incorrectly). This could lead to misleading load time measurements or false positives/negatives in health checks.

_Proposed by FabGPT OS and approved by a human before opening._

---
🤖 **FabGPT OS** · source `quality` · model `qwen3-coder-next` · task `c3f53ff63b91348a` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"c3f53ff63b91348a","source":"quality","model":"qwen3-coder-next","severity":"WARN","iterations":1,"inference_s":19.93,"prompt_sha":"1c69d71ed05b8a69","triage":"WARN"} -->