### PR TITLE
Normalize field values before checking for privacy indicators

### DIFF
--- a/checks/check_privacy_protected_whois.py
+++ b/checks/check_privacy_protected_whois.py
@@ -6,6 +6,21 @@ from whois.parser import PywhoisError
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+def _normalize_field_value(value):
+    """
+    Normalize a WHOIS field value to a lowercase string for privacy checking.
+    Handles strings, lists, dicts, and None values robustly.
+    """
+    if value is None:
+        return ''
+    if isinstance(value, str):
+        return value.lower()
+    if isinstance(value, list):
+        return ' '.join(str(v).lower() for v in value if v is not None)
+    if isinstance(value, dict):
+        return ' '.join(f"{k} {v}" for k, v in value.items() if v is not None)
+    return str(value).lower()
+
 def check_privacy_protected_whois(domain: str) -> str:
     """
     Check if a domain's WHOIS information indicates that it is privacy-protected with enhanced detection.
@@ -59,7 +74,7 @@ def check_privacy_protected_whois(domain: str) -> str:
             
             if field_value:
                 total_checks += 1
-                field_str = str(field_value).lower()
+                field_str = _normalize_field_value(field_value)
                 
                 if any(indicator in field_str for indicator in privacy_indicators):
                     privacy_score += 1
@@ -73,7 +88,8 @@ def check_privacy_protected_whois(domain: str) -> str:
             
             for field in critical_fields:
                 value = whois_data.get(field, '')
-                if not value or 'redacted' in str(value).lower() or 'withheld' in str(value).lower():
+                normalized = _normalize_field_value(value)
+                if not normalized or 'redacted' in normalized or 'withheld' in normalized:
                     redacted_count += 1
 
             if redacted_count >= 2:


### PR DESCRIPTION
### FabGPT — code quality

**File:** `checks/check_privacy_protected_whois.py`

**Rationale:** The current code converts field values to strings using `str(field_value)` but does not handle non-string types (e.g., lists, dicts) robustly. If `whois_data.get(field)` returns a list or dict (common in WHOIS responses), `str()` produces unhelpful output like `['example@example.com']` or `{'key': 'value'}`, causing privacy indicators to be missed or misdetected. Normalizing values to lowercase strings after flattening or extracting text improves accuracy.

_Proposed by FabGPT OS and approved by a human before opening._

---
🤖 **FabGPT OS** · source `quality` · model `qwen3-coder-next` · task `44fb9506f2871b66` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"44fb9506f2871b66","source":"quality","model":"qwen3-coder-next","severity":"WARN","iterations":1,"inference_s":18.72,"prompt_sha":"20144637b88a4918","triage":"WARN"} -->