### PR TITLE
Add `.DS_Store` to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ tests/
 *.log
 codeflash.yaml
 .venv
+.DS_Store


### PR DESCRIPTION
### FabGPT — l0-git remediation

**Gate:** `gitignore_coverage` · **Confidence:** deterministic

.gitignore does not cover `.DS_Store`. Generated by macOS/Windows/IDEs; never relevant to the project. Add `.DS_Store` to your .gitignore.

_Approved by a human before opening._

---
🤖 **FabGPT OS** · source `l0git` · model `deterministic` · task `0bcaf973944543e5` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"0bcaf973944543e5","source":"l0git","model":"deterministic","severity":"INFO","iterations":1,"inference_s":0.0,"triage":"INFO"} -->