### PR TITLE
Fix missing import for webdriver.ChromeOptions and FirefoxOptions

### DIFF
--- a/checks/check_browser_compatibility.py
+++ b/checks/check_browser_compatibility.py
@@ -1,5 +1,7 @@
 from selenium import webdriver
 from selenium.common.exceptions import WebDriverException
+from selenium.webdriver.chrome.options import Options as ChromeOptions
+from selenium.webdriver.firefox.options import Options as FirefoxOptions
 
 def check_browser_compatibility(website):
     """
@@ -23,8 +25,8 @@ def check_browser_compatibility(website):
 
     # List of drivers to test compatibility
     driver_configs = [
-        ("Chrome", webdriver.Chrome, webdriver.ChromeOptions),
-        ("Firefox", webdriver.Firefox, webdriver.FirefoxOptions),
+        ("Chrome", webdriver.Chrome, ChromeOptions),
+        ("Firefox", webdriver.Firefox, FirefoxOptions),
     ]
 
     compatible_browsers = 0


### PR DESCRIPTION
### FabGPT — code quality

**File:** `checks/check_browser_compatibility.py`

**Rationale:** The code uses `webdriver.ChromeOptions` and `webdriver.FirefoxOptions` directly, but these are not imported — only `webdriver` is imported. This will raise a `NameError` at runtime when the loop reaches the first browser test, causing the function to always return '🔴' or crash, making the compatibility check non-functional. This is a real defect visible in the import block.

_Proposed by FabGPT OS and approved by a human before opening._

---
🤖 **FabGPT OS** · source `quality` · model `qwen3-coder-next` · task `d8d6952ee5138e7f` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"d8d6952ee5138e7f","source":"quality","model":"qwen3-coder-next","severity":"INFO","iterations":1,"inference_s":6.72,"prompt_sha":"09d31cb12185bf56","triage":"INFO"} -->